### PR TITLE
Add support for modifying the query string parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@ return [
      * when using the JSON API paginator.
      */
     'max_results' => 30,
+    
+    /*
+     * The key of the page[x] query string parameter for page number.
+     */
+    'number_parameter' => 'number',
+
+    /*
+     * The key of the page[x] query string parameter for page size.
+     */
+    'size_parameter' => 'size',
 
     /*
      * The name of the macro that is added to the Eloquent query builder.

--- a/config/json-api-paginate.php
+++ b/config/json-api-paginate.php
@@ -9,6 +9,16 @@ return [
     'max_results' => 30,
 
     /*
+     * The key of the page[x] query string parameter for page number.
+     */
+    'number_parameter' => 'number',
+
+    /*
+     * The key of the page[x] query string parameter for page size.
+     */
+    'size_parameter' => 'size',
+
+    /*
      * The name of the macro that is added to the Eloquent query builder.
      */
     'method_name' => 'jsonPaginate',

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -33,20 +33,22 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
     {
         Builder::macro(config('json-api-paginate.method_name'), function (int $maxResults = null) {
             $configuredMaximum = config('json-api-paginate.max_results');
+            $numberParameter = config('json-api-paginate.number_parameter');
+            $sizeParameter = config('json-api-paginate.size_parameter');
 
             if (is_null($maxResults)) {
                 $maxResults = $configuredMaximum;
             }
 
-            $size = request()->input('page.size', $maxResults);
+            $size = request()->input('page.'.$sizeParameter, $maxResults);
 
             if ($size > $configuredMaximum) {
                 $size = $configuredMaximum;
             }
 
-            return $this->paginate($size, ['*'], 'page.number')
-                ->setPageName('page[number]')
-                ->appends(array_except(request()->input(), 'page.number'));
+            return $this->paginate($size, ['*'], 'page.'.$numberParameter)
+                ->setPageName('page['.$numberParameter.']')
+                ->appends(array_except(request()->input(), 'page.'.$numberParameter));
         });
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -19,4 +19,24 @@ class RequestTest extends TestCase
 
         $response->assertJsonFragment(['current_page' => 2]);
     }
+
+    /** @test */
+    public function it_will_use_the_configured_page_size_parameter()
+    {
+        config(['json-api-paginate.size_parameter' => 'modified_size']);
+
+        $response = $this->get('/?page[modified_size]=2');
+
+        $response->assertJsonFragment(['per_page' => '2']);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_number_parameter()
+    {
+        config(['json-api-paginate.number_parameter' => 'modified_number']);
+
+        $response = $this->get('/?page[modified_number]=2');
+
+        $response->assertJsonFragment(['current_page' => 2]);
+    }
 }


### PR DESCRIPTION
The [JSON API specs](http://jsonapi.org/format/#fetching-pagination) is agnostic to the actual query string parameter names (apart from using the `page[]` namespace) so I thought it'd be nice to support arbitrary parameter names.