### PR TITLE
[LaraPackagePort] Analyse for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,11 +17,11 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/database": "~5.4.17|~5.5.x-dev",
-        "illuminate/support": "~5.4.17|~5.5.x-dev"
+        "illuminate/database": "~5.4.17|~5.5.x-dev|~5.5.x-dev",
+        "illuminate/support": "~5.4.17|~5.5.x-dev|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.7|~3.5.x-dev",
+        "orchestra/testbench": "~3.4.7|~3.5.x-dev|~3.5.x-dev",
         "phpunit/phpunit": "^6.2"
     },
     "autoload": {
@@ -48,3 +48,4 @@
         }
     }
 }
+

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/database": "~5.4.17",
-        "illuminate/support": "~5.4.17"
+        "illuminate/database": "~5.4.17|~5.5.x-dev",
+        "illuminate/support": "~5.4.17|~5.5.x-dev"
     },
     "require-dev": {
-        "orchestra/testbench": "~3.4.7",
-        "phpunit/phpunit": "^6.1"
+        "orchestra/testbench": "~3.4.7|~3.5.x-dev",
+        "phpunit/phpunit": "^6.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This Pull-Requests help you to prepare your Package for Laravel 5.5. I've tested it automated and this was the PHPUnit Result:
PHPUnit 6.3-dev by Sebastian Bergmann and contributors.

Runtime:       PHP 7.1.7 with Xdebug 2.5.5
Configuration: /Users/lukaskammerling/Code/OSS/spatieLaravelphp5.5/storage/spatie.laravel-json-api-paginate/phpunit.xml.dist

........                                                            8 / 8 (100%)

Time: 4.63 seconds, Memory: 12.00MB

OK (8 tests, 8 assertions)

Generating code coverage report in Clover XML format ... done

Generating code coverage report in HTML format ... done

Nice looks really good! There are no Errors so it might work in Laravel 5.5 without any adjustments