### PR TITLE
Add default_size config and parameter option

### DIFF
--- a/config/json-api-paginate.php
+++ b/config/json-api-paginate.php
@@ -9,6 +9,12 @@ return [
     'max_results' => 30,
 
     /*
+     * The default number of results that will be returned
+     * when using the JSON API paginator.
+     */
+    'default_size' => 30,
+
+    /*
      * The key of the page[x] query string parameter for page number.
      */
     'number_parameter' => 'number',

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -31,12 +31,13 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
     protected function registerMacro()
     {
-        Builder::macro(config('json-api-paginate.method_name'), function (int $maxResults = null) {
+        Builder::macro(config('json-api-paginate.method_name'), function (int $maxResults = null, int $defaultSize = null) {
             $maxResults = $maxResults ?? config('json-api-paginate.max_results');
+            $defaultSize = $defaultSize ?? config('json-api-paginate.default_size');
             $numberParameter = config('json-api-paginate.number_parameter');
             $sizeParameter = config('json-api-paginate.size_parameter');
 
-            $size = request()->input('page.'.$sizeParameter, $maxResults);
+            $size = request()->input('page.'.$sizeParameter, $defaultSize);
 
             if ($size > $maxResults) {
                 $size = $maxResults;

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -15,9 +15,11 @@ class BuilderTest extends TestCase
     /** @test */
     public function it_returns_the_amount_of_records_specified_in_the_config_file()
     {
+        config()->set('json-api-paginate.default_size', 10);
+
         $paginator = TestModel::jsonPaginate();
 
-        $this->assertCount(30, $paginator);
+        $this->assertCount(10, $paginator);
     }
 
     /** @test */
@@ -31,8 +33,8 @@ class BuilderTest extends TestCase
     /** @test */
     public function it_will_not_return_more_records_that_the_configured_maximum()
     {
-        $paginator = TestModel::jsonPaginate(50);
+        $paginator = TestModel::jsonPaginate(15);
 
-        $this->assertCount(40, $paginator);
+        $this->assertCount(15, $paginator);
     }
 }

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -21,6 +21,14 @@ class RequestTest extends TestCase
     }
 
     /** @test */
+    public function it_will_use_the_default_page_size()
+    {
+        $response = $this->get('/');
+
+        $response->assertJsonFragment(['per_page' => 30]);
+    }
+
+    /** @test */
     public function it_will_use_the_configured_page_size_parameter()
     {
         config(['json-api-paginate.size_parameter' => 'modified_size']);


### PR DESCRIPTION
When no size parameter is provided in the url `jsonPaginate` used to fall back to the `max_results` for the page size. 

This PR adds a config option and optional parameter to set the default size yourself. This is usefull to allow returning a lot of data with `?page[size]=200` but keep the default number of results per page low.