### PR TITLE
Cast per_page / size to an integer

### DIFF
--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -37,7 +37,7 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
             $numberParameter = config('json-api-paginate.number_parameter');
             $sizeParameter = config('json-api-paginate.size_parameter');
 
-            $size = request()->input('page.'.$sizeParameter, $defaultSize);
+            $size = (int) request()->input('page.'.$sizeParameter, $defaultSize);
 
             if ($size > $maxResults) {
                 $size = $maxResults;


### PR DESCRIPTION
Per page / size is a string when passed via query params and thus comes out as a string in the resulting `meta` object unless we cast it to an int