### PR TITLE
With return all functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build
 composer.lock
 docs
 vendor
+*.sublime-project
+*.sublime-workspace

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@
 [![StyleCI](https://styleci.io/repos/94352951/shield?branch=master)](https://styleci.io/repos/94352951)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-json-api-paginate.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-json-api-paginate)
 
-In a vanilla Laravel application [the query builder paginators will listen to `page` request parameter](https://laravel.com/docs/5.4/pagination#paginating-query-builder-results). This works great, but it does not comply with [the json:api spec](http://jsonapi.org/). That spec [expects](http://jsonapi.org/examples/#pagination) the query builder paginator to listen to the `page[number]` and `page[size]` request parameters. 
+In a vanilla Laravel application [the query builder paginators will listen to `page` request parameter](https://laravel.com/docs/5.4/pagination#paginating-query-builder-results). This works great, but it does not comply with [the json:api spec](http://jsonapi.org/). That spec [expects](http://jsonapi.org/examples/#pagination) the query builder paginator to listen to the `page[number]` and `page[size]` request parameters.
+
+Setting `page[size]=0` will use the model's perPage() value (default 15).
+Setting `page[size]=-1` will make the page size equals to the total number of records, returning all results.
 
 This package adds a `jsonPaginate` method to the Eloquent query builder that listens to those parameters and adds [the pagination links the spec requires](http://jsonapi.org/format/#fetching-pagination).
 
@@ -44,14 +47,15 @@ return [
     /*
      * The maximum number of results that will be returned
      * when using the JSON API paginator.
+     * If set to 0, then no maxiumum will be applied
      */
-    'max_results' => 30,
+    'max_results' => 0,
 
     /*
      * The default number of results that will be returned
      * when using the JSON API paginator.
      */
-    'default_size' => 30,
+    'default_size' => 50,
 
     /*
      * The key of the page[x] query string parameter for page number.
@@ -134,7 +138,7 @@ The base code of this page was published on [this Laracasts forum thread](https:
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 In a vanilla Laravel application [the query builder paginators will listen to `page` request parameter](https://laravel.com/docs/5.4/pagination#paginating-query-builder-results). This works great, but it does not comply with [the json:api spec](http://jsonapi.org/). That spec [expects](http://jsonapi.org/examples/#pagination) the query builder paginator to listen to the `page[number]` and `page[size]` request parameters.
 
 Setting `page[size]=0` will use the model's perPage() value (default 15).
-Setting `page[size]=-1` will make the page size equals to the total number of records, returning all results.
+Setting `page[size]=-1` will make the page size equal to the total number of records, returning all results.
 
 This package adds a `jsonPaginate` method to the Eloquent query builder that listens to those parameters and adds [the pagination links the spec requires](http://jsonapi.org/format/#fetching-pagination).
 

--- a/config/json-api-paginate.php
+++ b/config/json-api-paginate.php
@@ -6,13 +6,13 @@ return [
      * The maximum number of results that will be returned
      * when using the JSON API paginator.
      */
-    'max_results' => 0,
+    'max_results' => 50,
 
     /*
      * The default number of results that will be returned
      * when using the JSON API paginator.
      */
-    'default_size' => 50,
+    'default_size' => 30,
 
     /*
      * The key of the page[x] query string parameter for page number.

--- a/config/json-api-paginate.php
+++ b/config/json-api-paginate.php
@@ -6,13 +6,13 @@ return [
      * The maximum number of results that will be returned
      * when using the JSON API paginator.
      */
-    'max_results' => 30,
+    'max_results' => 0,
 
     /*
      * The default number of results that will be returned
      * when using the JSON API paginator.
      */
-    'default_size' => 30,
+    'default_size' => 50,
 
     /*
      * The key of the page[x] query string parameter for page number.

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -39,8 +39,12 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
             $size = (int) request()->input('page.'.$sizeParameter, $defaultSize);
 
-            if ($size > $maxResults) {
+            if ($maxResults && $size > $maxResults) {
                 $size = $maxResults;
+            }
+
+            if ($size === -1) {
+                $size = $this->toBase()->getCountForPagination();
             }
 
             $paginator = $this->paginate($size, ['*'], 'page.'.$numberParameter)

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -39,6 +39,14 @@ class BuilderTest extends TestCase
     }
 
     /** @test */
+    public function it_will_return_the_configured_default_when_maximum_is_removed()
+    {
+        $paginator = TestModel::jsonPaginate(0);
+
+        $this->assertCount(30, $paginator);
+    }
+
+    /** @test */
     public function it_can_set_a_custom_base_url_in_the_config_file()
     {
         config()->set('json-api-paginate.base_url', 'https://example.com');

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -13,6 +13,14 @@ class RequestTest extends TestCase
     }
 
     /** @test */
+    public function it_will_change_the_page_size_parameter_to_all_available_when_minus_one_passed()
+    {
+        $response = $this->get('/?page[size]=-1');
+
+        $response->assertJsonFragment(['per_page' => 40]);
+    }
+
+    /** @test */
     public function it_will_discover_the_page_number_parameter()
     {
         $response = $this->get('/?page[number]=2');


### PR DESCRIPTION
I wanted to be able to switch off the maximum results, and also to be able to request that all results be returned. This branch allows the following:

Setting `page[size]=0` will use the model's perPage() value (default 15).
Setting `page[size]=-1` will make the page size equal to the total number of records, returning all results.