### PR TITLE
add `jsonPaginate` method to `HasManyThrough` and `BelongsToMany`

### DIFF
--- a/src/ForwardPagination.php
+++ b/src/ForwardPagination.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\JsonApiPaginate;
+
+use Illuminate\Support\Arr;
+
+class ForwardPagination
+{
+    public function execute($builder, int $maxResults = null, int $defaultSize = null) {
+
+        $maxResults = $maxResults ?? config('json-api-paginate.max_results');
+        $defaultSize = $defaultSize ?? config('json-api-paginate.default_size');
+        $numberParameter = config('json-api-paginate.number_parameter');
+        $sizeParameter = config('json-api-paginate.size_parameter');
+        $paginationParameter = config('json-api-paginate.pagination_parameter');
+        $paginationMethod = config('json-api-paginate.use_simple_pagination') ? 'simplePaginate' : 'paginate';
+
+        $size = (int) request()->input($paginationParameter.'.'.$sizeParameter, $defaultSize);
+
+        $size = $size > $maxResults ? $maxResults : $size;
+
+        $paginator = $builder
+            ->{$paginationMethod}($size, ['*'], $paginationParameter.'.'.$numberParameter)
+            ->setPageName($paginationParameter.'['.$numberParameter.']')
+            ->appends(Arr::except(request()->input(), $paginationParameter.'.'.$numberParameter));
+
+        if (! is_null(config('json-api-paginate.base_url'))) {
+            $paginator->setPath(config('json-api-paginate.base_url'));
+        }
+
+        return $paginator;
+    }
+}


### PR DESCRIPTION
> Resolves https://github.com/spatie/laravel-json-api-paginate/issues/45

The `BelongsToMany` and `HasManyThrough` methods overwrite the default `paginate` and `simplePaginate` methods to alter the SQL queries before they are executed to handle pivot attribute aliasing which results in faulty results with this package if you use those types of relationships because only the `Builder` class has the `jsonPaginate` macro added to it which results in an SQL query being executed that won't alias pivot attributes and thus overwrite attributes of your primary model.

The signatures of `paginate` and `simplePaginate` are the same on all builders/classes so I've added a `ForwardPagination` class which contains the logic that was previously only bound via `Builder::macro`. Now that we need to bind this logic to 3 different builders we can simply call `ForwardPagination::execute` and pass in the respective builder as the first argument and it'll behave as before this change.