### PR TITLE
Adds the JsonPaginate macro to the base Query Builder

### DIFF
--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -2,7 +2,8 @@
 
 namespace Spatie\JsonApiPaginate;
 
-use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
 
@@ -26,7 +27,7 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
     protected function registerMacro()
     {
-        Builder::macro(config('json-api-paginate.method_name'), function (int $maxResults = null, int $defaultSize = null) {
+        $macro = function (int $maxResults = null, int $defaultSize = null) {
             $maxResults = $maxResults ?? config('json-api-paginate.max_results');
             $defaultSize = $defaultSize ?? config('json-api-paginate.default_size');
             $numberParameter = config('json-api-paginate.number_parameter');
@@ -48,6 +49,9 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
             }
 
             return $paginator;
-        });
+        };
+
+        EloquentBuilder::macro(config('json-api-paginate.method_name'), $macro);
+        BaseBuilder::macro(config('json-api-paginate.method_name'), $macro);
     }
 }

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -2,6 +2,9 @@
 
 namespace Spatie\JsonApiPaginate\Test;
 
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
 class BuilderTest extends TestCase
 {
     /** @test */
@@ -56,5 +59,12 @@ class BuilderTest extends TestCase
         $paginator = TestModel::jsonPaginate();
 
         $this->assertFalse(method_exists($paginator, 'total'));
+    }
+
+    /** @test */
+    public function it_can_use_base_query_builder()
+    {
+        $paginator = DB::table('test_models')->jsonPaginate();
+        $this->assertEquals('http://localhost?page%5Bnumber%5D=2', $paginator->nextPageUrl());
     }
 }


### PR DESCRIPTION
In some places in my application, I want to use the base query builder via DB::table, but still have it paginate.

Since the API is the same, this simply applies the macro to both versions of the `Builder` class.