### PR TITLE
[Draft] Add jsonPaginate() method to BelongsToMany and HasManyThrough

### DIFF
--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Spatie\JsonApiPaginate;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
@@ -53,5 +55,7 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
         EloquentBuilder::macro(config('json-api-paginate.method_name'), $macro);
         BaseBuilder::macro(config('json-api-paginate.method_name'), $macro);
+        BelongsToMany::macro(config('json-api-paginate.method_name'), $macro);
+        HasManyThrough::macro(config('json-api-paginate.method_name'), $macro);
     }
 }


### PR DESCRIPTION
- Add jsonPaginate() method to BelongsToMany and HasManyThrough relationships using macro().

This ia a re-open based on [Pull Request #47](https://github.com/spatie/laravel-json-api-paginate/pull/47) which was closed.
Also related: [Issue #631](https://github.com/spatie/laravel-query-builder/issues/631)

The `BelongsToMany` and `HasManyThrough` relations have their own `paginate` and `simplePaginate` methods. At the moment only the `Query\Builder` and `Eloquent\Builder' classes have the `jsonPaginate` macro added to it. This results in the `jsonPaginate()`method returning merged columns from the pivot table instead of the actual model. (see this comment: [Issue #631](https://github.com/spatie/laravel-query-builder/issues/631#issuecomment-879454513))

The signatures of `paginate` and `simplePaginate` are the same on the `Builder` classes and `Relation` classes. 
For that reason I added the configured macro to the `BelongsToMany` and `HasManyThrough` relations as well.

Todo: Add tests to check if they work as expected

