### PR TITLE
Make negetive page[size] exception safe

### DIFF
--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -37,9 +37,14 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
             $size = (int) request()->input($paginationParameter.'.'.$sizeParameter, $defaultSize);
 
-            $size = $size <= 0 ? $defaultSize : $size;
-            $size = $size > $maxResults ? $maxResults : $size;
-
+            if ($size <= 0) {
+                $size = $defaultSize;
+            }
+            
+            if ($size > $maxResults) {
+                $size = $maxResults;
+            }
+            
             $paginator = $this
                 ->{$paginationMethod}($size, ['*'], $paginationParameter.'.'.$numberParameter)
                 ->setPageName($paginationParameter.'['.$numberParameter.']')

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -37,6 +37,7 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
             $size = (int) request()->input($paginationParameter.'.'.$sizeParameter, $defaultSize);
 
+            $size = $size <= 0 ? $defaultSize : $size;
             $size = $size > $maxResults ? $maxResults : $size;
 
             $paginator = $this

--- a/tests/RequestTest.php
+++ b/tests/RequestTest.php
@@ -47,4 +47,34 @@ class RequestTest extends TestCase
 
         $response->assertJsonFragment(['current_page' => 2]);
     }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_zero()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=0');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_negative()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=-1');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_illegal()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=Rpfwj5N1b7');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
 }


### PR DESCRIPTION
If `page[size]` is negative, QueryException will be raised saying 

> "SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '0' at line 1 (SQL: select * from `products` offset 0)"

This change fixes this by quietly setting page size to `$defaultSize` when it is negative. This is also the behavior when page number is negative.