### PR TITLE
Add macros for BelongsToMany and HasManyThrough

### DIFF
--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Spatie\JsonApiPaginate;
 
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider;
@@ -65,5 +67,7 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
 
         EloquentBuilder::macro(config('json-api-paginate.method_name'), $macro);
         BaseBuilder::macro(config('json-api-paginate.method_name'), $macro);
+        BelongsToMany::macro(config('json-api-paginate.method_name'), $macro);
+        HasManyThrough::macro(config('json-api-paginate.method_name'), $macro);
     }
 }

--- a/tests/BelongsToMany/BuilderTest.php
+++ b/tests/BelongsToMany/BuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\BelongsToMany;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class BuilderTest extends TestCase
+{
+    /** @test */
+    public function it_can_paginate_records()
+    {
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertEquals('http://localhost?page%5Bnumber%5D=2', $paginator->nextPageUrl());
+    }
+
+    /** @test */
+    public function it_can_paginate_records_with_cursor()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertEquals('http://localhost?page%5Bcursor%5D=eyJyZXN1bHRfbW9kZWxzLmlkIjozMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', $paginator->nextPageUrl());
+    }
+
+    /** @test */
+    public function it_returns_the_amount_of_records_specified_in_the_config_file()
+    {
+        config()->set('json-api-paginate.default_size', 10);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertCount(10, $paginator);
+    }
+
+    /** @test */
+    public function it_returns_the_amount_of_records_specified_in_the_config_file_using_cursor()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+        config()->set('json-api-paginate.default_size', 10);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertCount(10, $paginator);
+    }
+
+    /** @test */
+    public function it_can_return_the_specified_amount_of_records()
+    {
+        $paginator = TestModel::find(1)->results()->jsonPaginate(15);
+
+        $this->assertCount(15, $paginator);
+    }
+
+    /** @test */
+    public function it_can_return_the_specified_amount_of_records_with_cursor()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate(15);
+
+        $this->assertCount(15, $paginator);
+    }
+
+    /** @test */
+    public function it_will_not_return_more_records_that_the_configured_maximum()
+    {
+        $paginator = TestModel::find(1)->results()->jsonPaginate(15);
+
+        $this->assertCount(15, $paginator);
+    }
+
+    /** @test */
+    public function it_can_set_a_custom_base_url_in_the_config_file()
+    {
+        config()->set('json-api-paginate.base_url', 'https://example.com');
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertEquals('https://example.com?page%5Bnumber%5D=2', $paginator->nextPageUrl());
+    }
+
+    /** @test */
+    public function it_can_use_simple_pagination()
+    {
+        config()->set('json-api-paginate.use_simple_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertFalse(method_exists($paginator, 'total'));
+    }
+
+    /** @test */
+    public function it_can_use_cursor_pagination()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertFalse(method_exists($paginator, 'total'));
+    }
+}

--- a/tests/BelongsToMany/RequestTest.php
+++ b/tests/BelongsToMany/RequestTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\BelongsToMany;
+
+class RequestTest extends TestCase
+{
+    /** @test */
+    public function it_will_discover_the_page_size_parameter()
+    {
+        $response = $this->get('/?page[size]=2');
+
+        $response->assertJsonFragment(['per_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_discover_the_page_number_parameter()
+    {
+        $response = $this->get('/?page[number]=2');
+
+        $response->assertJsonFragment(['current_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_discover_the_cursor_parameter()
+    {
+        $response = $this->get('cursor/?page[cursor]=eyJyZXN1bHRfbW9kZWxzLmlkIjozMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ');
+
+        $response->assertJsonFragment(['prev_cursor' => 'eyJyZXN1bHRfbW9kZWxzLmlkIjozMSwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0']);
+    }
+
+    /** @test */
+    public function it_will_use_the_default_page_size()
+    {
+        $response = $this->get('/');
+
+        $response->assertJsonFragment(['per_page' => 30]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_size_parameter()
+    {
+        config(['json-api-paginate.size_parameter' => 'modified_size']);
+
+        $response = $this->get('/?page[modified_size]=2');
+
+        $response->assertJsonFragment(['per_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_size_parameter_for_cursor()
+    {
+        config(['json-api-paginate.size_parameter' => 'modified_size']);
+
+        $response = $this->get('cursor/?page[modified_size]=2');
+
+        $response->assertJsonFragment(['per_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_number_parameter()
+    {
+        config(['json-api-paginate.number_parameter' => 'modified_number']);
+
+        $response = $this->get('/?page[modified_number]=2');
+
+        $response->assertJsonFragment(['current_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_cursor_parameter()
+    {
+        config(['json-api-paginate.cursor_parameter' => 'modified_cursor']);
+
+        $response = $this->get('cursor/?page[size]=10&page[modified_cursor]=eyJyZXN1bHRfbW9kZWxzLmlkIjoxMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ');
+
+        $response->assertJsonFragment(['next_cursor' => 'eyJyZXN1bHRfbW9kZWxzLmlkIjoyMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ']);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_size_parameter_for_cursor()
+    {
+        $response = $this->get('cursor/?page[size]=10');
+
+        $response->assertJsonFragment(['next_cursor' => 'eyJyZXN1bHRfbW9kZWxzLmlkIjoxMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ']);
+    }
+
+    public function it_will_use_default_size_when_page_size_is_zero()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=0');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_negative()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=-1');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_illegal()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=Rpfwj5N1b7');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+}

--- a/tests/BelongsToMany/ResultModel.php
+++ b/tests/BelongsToMany/ResultModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\BelongsToMany;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ResultModel extends Model
+{
+    protected $guarded = [];
+
+    public function tests()
+    {
+        return $this->belongsToMany(TestModel::class);
+    }
+}

--- a/tests/BelongsToMany/TestCase.php
+++ b/tests/BelongsToMany/TestCase.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\BelongsToMany;
+
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Application;
+use Orchestra\Testbench\TestCase as Orchestra;
+use Route;
+
+abstract class TestCase extends Orchestra
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create('2017', '1', '1', '1', '1', '1'));
+
+        $this->setUpDatabase($this->app);
+
+        $this->setUpRoutes($this->app);
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            \Spatie\JsonApiPaginate\JsonApiPaginateServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function setUpDatabase($app)
+    {
+        $app['db']->connection()->getSchemaBuilder()->create('test_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('result_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('result_model_test_model', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('result_model_id');
+            $table->foreignId('test_model_id');
+        });
+
+        $test = TestModel::create(['name' => "test1"]);
+
+        foreach (range(1, 40) as $index) {
+            $result = ResultModel::create(['name' => "result{$index}"]);
+
+            $test->results()->attach($result);
+        }
+    }
+
+    protected function setUpRoutes(Application $app)
+    {
+        Route::any('/', function () {
+            return TestModel::find(1)->results()->jsonPaginate();
+        });
+
+        Route::any('cursor/', function () {
+            config()->set('json-api-paginate.use_cursor_pagination', true);
+
+            return TestModel::find(1)->results()->orderBy('result_models.id')->jsonPaginate();
+        });
+    }
+}

--- a/tests/BelongsToMany/TestModel.php
+++ b/tests/BelongsToMany/TestModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\BelongsToMany;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestModel extends Model
+{
+    protected $guarded = [];
+
+    public function results()
+    {
+        return $this->belongsToMany(ResultModel::class);
+    }
+}

--- a/tests/HasManyThrough/BuilderTest.php
+++ b/tests/HasManyThrough/BuilderTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\HasManyThrough;
+
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+class BuilderTest extends TestCase
+{
+    /** @test */
+    public function it_can_paginate_records()
+    {
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertEquals('http://localhost?page%5Bnumber%5D=2', $paginator->nextPageUrl());
+    }
+
+    /** @test */
+    public function it_can_paginate_records_with_cursor()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertEquals('http://localhost?page%5Bcursor%5D=eyJyZXN1bHRfbW9kZWxzLmlkIjozMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ', $paginator->nextPageUrl());
+    }
+
+    /** @test */
+    public function it_returns_the_amount_of_records_specified_in_the_config_file()
+    {
+        config()->set('json-api-paginate.default_size', 10);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertCount(10, $paginator);
+    }
+
+    /** @test */
+    public function it_returns_the_amount_of_records_specified_in_the_config_file_using_cursor()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+        config()->set('json-api-paginate.default_size', 10);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertCount(10, $paginator);
+    }
+
+    /** @test */
+    public function it_can_return_the_specified_amount_of_records()
+    {
+        $paginator = TestModel::find(1)->results()->jsonPaginate(15);
+
+        $this->assertCount(15, $paginator);
+    }
+
+    /** @test */
+    public function it_can_return_the_specified_amount_of_records_with_cursor()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate(15);
+
+        $this->assertCount(15, $paginator);
+    }
+
+    /** @test */
+    public function it_will_not_return_more_records_that_the_configured_maximum()
+    {
+        $paginator = TestModel::find(1)->results()->jsonPaginate(15);
+
+        $this->assertCount(15, $paginator);
+    }
+
+    /** @test */
+    public function it_can_set_a_custom_base_url_in_the_config_file()
+    {
+        config()->set('json-api-paginate.base_url', 'https://example.com');
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertEquals('https://example.com?page%5Bnumber%5D=2', $paginator->nextPageUrl());
+    }
+
+    /** @test */
+    public function it_can_use_simple_pagination()
+    {
+        config()->set('json-api-paginate.use_simple_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertFalse(method_exists($paginator, 'total'));
+    }
+
+    /** @test */
+    public function it_can_use_cursor_pagination()
+    {
+        config()->set('json-api-paginate.use_cursor_pagination', true);
+
+        $paginator = TestModel::find(1)->results()->jsonPaginate();
+
+        $this->assertFalse(method_exists($paginator, 'total'));
+    }
+}

--- a/tests/HasManyThrough/EnvironmentModel.php
+++ b/tests/HasManyThrough/EnvironmentModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\HasManyThrough;
+
+use Illuminate\Database\Eloquent\Model;
+
+class EnvironmentModel extends Model
+{
+    protected $guarded = [];
+
+    public function test()
+    {
+        return $this->belongsTo(TestModel::class, 'test_model_id');
+    }
+
+    public function results()
+    {
+        return $this->hasMany(ResultModel::class);
+    }
+}

--- a/tests/HasManyThrough/RequestTest.php
+++ b/tests/HasManyThrough/RequestTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\HasManyThrough;
+
+class RequestTest extends TestCase
+{
+    /** @test */
+    public function it_will_discover_the_page_size_parameter()
+    {
+        $response = $this->get('/?page[size]=2');
+
+        $response->assertJsonFragment(['per_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_discover_the_page_number_parameter()
+    {
+        $response = $this->get('/?page[number]=2');
+
+        $response->assertJsonFragment(['current_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_discover_the_cursor_parameter()
+    {
+        $response = $this->get('cursor/?page[cursor]=eyJyZXN1bHRfbW9kZWxzLmlkIjozMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ');
+
+        $response->assertJsonFragment(['prev_cursor' => 'eyJyZXN1bHRfbW9kZWxzLmlkIjozMSwiX3BvaW50c1RvTmV4dEl0ZW1zIjpmYWxzZX0']);
+    }
+
+    /** @test */
+    public function it_will_use_the_default_page_size()
+    {
+        $response = $this->get('/');
+
+        $response->assertJsonFragment(['per_page' => 30]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_size_parameter()
+    {
+        config(['json-api-paginate.size_parameter' => 'modified_size']);
+
+        $response = $this->get('/?page[modified_size]=2');
+
+        $response->assertJsonFragment(['per_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_size_parameter_for_cursor()
+    {
+        config(['json-api-paginate.size_parameter' => 'modified_size']);
+
+        $response = $this->get('cursor/?page[modified_size]=2');
+
+        $response->assertJsonFragment(['per_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_page_number_parameter()
+    {
+        config(['json-api-paginate.number_parameter' => 'modified_number']);
+
+        $response = $this->get('/?page[modified_number]=2');
+
+        $response->assertJsonFragment(['current_page' => 2]);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_cursor_parameter()
+    {
+        config(['json-api-paginate.cursor_parameter' => 'modified_cursor']);
+
+        $response = $this->get('cursor/?page[size]=10&page[modified_cursor]=eyJyZXN1bHRfbW9kZWxzLmlkIjoxMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ');
+
+        $response->assertJsonFragment(['next_cursor' => 'eyJyZXN1bHRfbW9kZWxzLmlkIjoyMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ']);
+    }
+
+    /** @test */
+    public function it_will_use_the_configured_size_parameter_for_cursor()
+    {
+        $response = $this->get('cursor/?page[size]=10');
+
+        $response->assertJsonFragment(['next_cursor' => 'eyJyZXN1bHRfbW9kZWxzLmlkIjoxMCwiX3BvaW50c1RvTmV4dEl0ZW1zIjp0cnVlfQ']);
+    }
+
+    public function it_will_use_default_size_when_page_size_is_zero()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=0');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_negative()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=-1');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+
+    /** @test */
+    public function it_will_use_default_size_when_page_size_is_illegal()
+    {
+        $default_size = config('json-api-paginate.default_size');
+
+        $response = $this->get('/?page[size]=Rpfwj5N1b7');
+
+        $response->assertJsonFragment(['per_page' => $default_size]);
+    }
+}

--- a/tests/HasManyThrough/ResultModel.php
+++ b/tests/HasManyThrough/ResultModel.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\HasManyThrough;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ResultModel extends Model
+{
+    protected $guarded = [];
+
+    public function environment()
+    {
+        return $this->belongsTo(EnvironmentModel::class, 'environment_model_id');
+    }
+}

--- a/tests/HasManyThrough/TestCase.php
+++ b/tests/HasManyThrough/TestCase.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\HasManyThrough;
+
+use Carbon\Carbon;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Foundation\Application;
+use Orchestra\Testbench\TestCase as Orchestra;
+use Route;
+
+abstract class TestCase extends Orchestra
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create('2017', '1', '1', '1', '1', '1'));
+
+        $this->setUpDatabase($this->app);
+
+        $this->setUpRoutes($this->app);
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     *
+     * @return array
+     */
+    protected function getPackageProviders($app)
+    {
+        return [
+            \Spatie\JsonApiPaginate\JsonApiPaginateServiceProvider::class,
+        ];
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function getEnvironmentSetUp($app)
+    {
+        $app['config']->set('database.default', 'sqlite');
+        $app['config']->set('database.connections.sqlite', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
+
+        $app['config']->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
+    }
+
+    /**
+     * @param \Illuminate\Foundation\Application $app
+     */
+    protected function setUpDatabase($app)
+    {
+        $app['db']->connection()->getSchemaBuilder()->create('test_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('environment_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('test_model_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $app['db']->connection()->getSchemaBuilder()->create('result_models', function (Blueprint $table) {
+            $table->increments('id');
+            $table->foreignId('environment_model_id');
+            $table->string('name');
+            $table->timestamps();
+        });
+
+        $test = TestModel::create(['name' => "test1"]);
+
+        foreach (range(1, 4) as $index) {
+            $environment = new EnvironmentModel(['name' => "environment{$index}"]);
+            $environment->test()->associate($test);
+            $environment->save();
+
+            foreach (range(1, 40) as $index2) {
+                $result = new ResultModel(['name' => "result{$index2}"]);
+                $result->environment()->associate($environment);
+                $result->save();
+            }
+        }
+    }
+
+    protected function setUpRoutes(Application $app)
+    {
+        Route::any('/', function () {
+            return TestModel::find(1)->results()->jsonPaginate();
+        });
+
+        Route::any('cursor/', function () {
+            config()->set('json-api-paginate.use_cursor_pagination', true);
+
+            return TestModel::find(1)->results()->orderBy('result_models.id')->jsonPaginate();
+        });
+    }
+}

--- a/tests/HasManyThrough/TestModel.php
+++ b/tests/HasManyThrough/TestModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\JsonApiPaginate\Test\HasManyThrough;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TestModel extends Model
+{
+    protected $guarded = [];
+
+    public function environments()
+    {
+        return $this->hasMany(EnvironmentModel::class);
+    }
+
+    public function results()
+    {
+        return $this->hasManyThrough(ResultModel::class, EnvironmentModel::class);
+    }
+}


### PR DESCRIPTION
I'm adding macros for BelongsToMany and HasManyThrough relations.

To illustrate the current problems I have attached two screenshots, before and after the implementation.

Before/without the macros the id column from the pivot is merged with the model and produces a false result:
<img width="791" alt="CleanShot 3@2x" src="https://user-images.githubusercontent.com/15112900/194905281-5f180aee-f2bb-4cf1-a195-2eb4cbc92a14.png">

With the added macro the result set is correct and id and pivot table aren't merged:
<img width="916" alt="CleanShot 2@2x" src="https://user-images.githubusercontent.com/15112900/194905296-09b98519-40f0-4f9d-9598-2ec13c15e83f.png">

Test have been added.
