### PR TITLE
Add PHP 8.2 Support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1]
+        php: [8.2, 8.1, 8.0, 7.4, 7.3]
         laravel: [9.*, 8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
 
       -   name: Setup Problem Matches


### PR DESCRIPTION
# Summary

This PR adds PHP 8.2 to the tests workflow.


_id:php82-support/v1_