### PR TITLE
Updated package for fast-paginate

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ return [
     'use_cursor_pagination' => false,
 
     /*
-     * use simpleFastPaginate() or fastPaginate from https://github.com/hammerstonedev/fast-paginate
-     * use may installed it via `composer require hammerstone/fast-paginate`
+     * use simpleFastPaginate() or fastPaginate from https://github.com/aarondfrancis/fast-paginate
+     * use may installed it via `composer require aaronfrancis/fast-paginate`
      */
     'use_fast_pagination' => false,
 

--- a/config/json-api-paginate.php
+++ b/config/json-api-paginate.php
@@ -47,8 +47,8 @@ return [
     'use_cursor_pagination' => false,
 
     /*
-     * use simpleFastPaginate() or fastPaginate from https://github.com/hammerstonedev/fast-paginate
-     * use may installed it via `composer require hammerstone/fast-paginate`
+     * use simpleFastPaginate() or fastPaginate from https://github.com/aarondfrancis/fast-paginate
+     * use may installed it via `composer require aaronfrancis/fast-paginate`
      */
     'use_fast_pagination' => false,
 

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -45,7 +45,7 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
                         : (config('json-api-paginate.use_fast_pagination') ? 'fastPaginate' : 'paginate')
                 );
 
-            if (config('json-api-paginate.use_fast_pagination') && ! InstalledVersions::isInstalled('hammerstone/fast-paginate')) {
+            if (config('json-api-paginate.use_fast_pagination') && ! (InstalledVersions::isInstalled('hammerstone/fast-paginate') || InstalledVersions::isInstalled('aaronfrancis/fast-paginate'))) {
                 abort(500, 'You need to install hammerstone/fast-paginate to use fast pagination.');
             }
 


### PR DESCRIPTION
Hammerstone fast paginate changed the namespace and it's now under `aaronfrancis/fast-paginate` => https://github.com/aarondfrancis/fast-paginate