### PR TITLE
Support spatie/laravel-fast-paginate for fast pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,20 @@ $model = YourModel::find(1);
 $model->relation()->jsonPaginate();
 ```
 
+### Fast pagination
+
+With `limit`/`offset` pagination, the database gets slower the deeper you page, because it has to walk past every skipped row. A deferred join avoids that by first fetching only the primary keys for the page, and then fetching the full rows for those keys.
+
+Install [spatie/laravel-fast-paginate](https://github.com/spatie/laravel-fast-paginate) to get that behavior.
+
+```bash
+composer require spatie/laravel-fast-paginate
+```
+
+Next, set `use_fast_pagination` to `true` in the config file. From then on, `jsonPaginate` calls `fastPaginate` instead of `paginate` (or `simpleFastPaginate` when `use_simple_pagination` is on). Nothing else changes, as the method signature and the returned paginator stay the same.
+
+The older `aaronfrancis/fast-paginate` and `hammerstone/fast-paginate` packages are recognized as well.
+
 ### Override default behavior
 
 By default the maximum page size is set to 30. You can change this number in the `config` file or just pass the value to  `jsonPaginate`.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,9 @@ return [
     'use_cursor_pagination' => false,
 
     /*
-     * use simpleFastPaginate() or fastPaginate from https://github.com/aarondfrancis/fast-paginate
-     * use may installed it via `composer require aaronfrancis/fast-paginate`
+     * Use fastPaginate() or simpleFastPaginate() instead of the regular paginators.
+     * These are added by a separate package, such as spatie/laravel-fast-paginate,
+     * which you can install with `composer require spatie/laravel-fast-paginate`.
      */
     'use_fast_pagination' => false,
 

--- a/config/json-api-paginate.php
+++ b/config/json-api-paginate.php
@@ -47,8 +47,9 @@ return [
     'use_cursor_pagination' => false,
 
     /*
-     * use simpleFastPaginate() or fastPaginate from https://github.com/aarondfrancis/fast-paginate
-     * use may installed it via `composer require aaronfrancis/fast-paginate`
+     * Use fastPaginate() or simpleFastPaginate() instead of the regular paginators.
+     * These are added by a separate package, such as spatie/laravel-fast-paginate,
+     * which you can install with `composer require spatie/laravel-fast-paginate`.
      */
     'use_fast_pagination' => false,
 

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\JsonApiPaginate;
 
-use Composer\InstalledVersions;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -45,8 +44,17 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
                         : (config('json-api-paginate.use_fast_pagination') ? 'fastPaginate' : 'paginate')
                 );
 
-            if (!method_exists($this, $paginationMethod)) {
-                abort(500, 'You need a fast pagination service provider such as aaronfrancis/fast-paginate to use fast pagination.');
+            if (config('json-api-paginate.use_fast_pagination')) {
+                // Fast pagination is added by a macro, so `method_exists` would never see
+                // it. Checking for the macro instead means any package that registers
+                // one will do, rather than a hardcoded list of known packages.
+                $providesFastPagination = $this instanceof EloquentBuilder
+                    ? EloquentBuilder::hasGlobalMacro($paginationMethod) || $this->hasMacro($paginationMethod)
+                    : $this::hasMacro($paginationMethod);
+
+                if (! $providesFastPagination) {
+                    abort(500, "No installed package provides a `{$paginationMethod}` method. Install one, such as spatie/laravel-fast-paginate, or turn off `use_fast_pagination`.");
+                }
             }
 
             $size = (int) request()->input($paginationParameter.'.'.$sizeParameter, $defaultSize);

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\JsonApiPaginate;
 
+use Composer\InstalledVersions;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
@@ -44,17 +45,14 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
                         : (config('json-api-paginate.use_fast_pagination') ? 'fastPaginate' : 'paginate')
                 );
 
-            if (config('json-api-paginate.use_fast_pagination')) {
-                // Fast pagination is added by a macro, so `method_exists` would never see
-                // it. Checking for the macro instead means any package that registers
-                // one will do, rather than a hardcoded list of known packages.
-                $providesFastPagination = $this instanceof EloquentBuilder
-                    ? EloquentBuilder::hasGlobalMacro($paginationMethod) || $this->hasMacro($paginationMethod)
-                    : $this::hasMacro($paginationMethod);
+            $fastPaginationPackages = [
+                'spatie/laravel-fast-paginate',
+                'aaronfrancis/fast-paginate',
+                'hammerstone/fast-paginate',
+            ];
 
-                if (! $providesFastPagination) {
-                    abort(500, "No installed package provides a `{$paginationMethod}` method. Install one, such as spatie/laravel-fast-paginate, or turn off `use_fast_pagination`.");
-                }
+            if (config('json-api-paginate.use_fast_pagination') && ! Arr::first($fastPaginationPackages, fn (string $package) => InstalledVersions::isInstalled($package))) {
+                abort(500, 'You need to install spatie/laravel-fast-paginate to use fast pagination.');
             }
 
             $size = (int) request()->input($paginationParameter.'.'.$sizeParameter, $defaultSize);

--- a/src/JsonApiPaginateServiceProvider.php
+++ b/src/JsonApiPaginateServiceProvider.php
@@ -45,8 +45,8 @@ class JsonApiPaginateServiceProvider extends ServiceProvider
                         : (config('json-api-paginate.use_fast_pagination') ? 'fastPaginate' : 'paginate')
                 );
 
-            if (config('json-api-paginate.use_fast_pagination') && ! (InstalledVersions::isInstalled('hammerstone/fast-paginate') || InstalledVersions::isInstalled('aaronfrancis/fast-paginate'))) {
-                abort(500, 'You need to install hammerstone/fast-paginate to use fast pagination.');
+            if (!method_exists($this, $paginationMethod)) {
+                abort(500, 'You need a fast pagination service provider such as aaronfrancis/fast-paginate to use fast pagination.');
             }
 
             $size = (int) request()->input($paginationParameter.'.'.$sizeParameter, $defaultSize);

--- a/tests/FastPaginationTest.php
+++ b/tests/FastPaginationTest.php
@@ -1,50 +1,72 @@
 <?php
 
+use Composer\InstalledVersions;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
-use Illuminate\Support\Facades\DB;
 use Spatie\JsonApiPaginate\Test\TestModel;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 
-// Eloquent's builder keeps its global macros in a static, and has no way to unregister
-// one, so we put back whatever was registered before each test.
 beforeEach(function () {
     config()->set('json-api-paginate.use_fast_pagination', true);
 
+    $this->installedPackages = InstalledVersions::getAllRawData()[0];
+
+    // Eloquent's builder keeps its global macros in a static, and has no way to
+    // unregister one, so we put back whatever was registered before.
     $this->registeredMacros = new ReflectionProperty(EloquentBuilder::class, 'macros');
     $this->originalMacros = $this->registeredMacros->getValue();
 });
 
 afterEach(function () {
+    InstalledVersions::reload($this->installedPackages);
+
     $this->registeredMacros->setValue(null, $this->originalMacros);
 });
 
-it('uses the fastPaginate macro when a package provides one', function () {
+function pretendPackageIsInstalled(string $package): void
+{
+    $installed = InstalledVersions::getAllRawData()[0];
+
+    $installed['versions'][$package] = [
+        'pretty_version' => '1.0.0',
+        'version' => '1.0.0.0',
+        'type' => 'library',
+        'install_path' => __DIR__,
+        'aliases' => [],
+        'reference' => null,
+        'dev_requirement' => false,
+    ];
+
+    InstalledVersions::reload($installed);
+
     EloquentBuilder::macro('fastPaginate', fn (...$arguments) => $this->paginate(...$arguments));
+    EloquentBuilder::macro('simpleFastPaginate', fn (...$arguments) => $this->simplePaginate(...$arguments));
+}
+
+it('fast paginates when a known package is installed', function (string $package) {
+    pretendPackageIsInstalled($package);
 
     expect(TestModel::jsonPaginate()->nextPageUrl())
         ->toEqual('http://localhost?page%5Bnumber%5D=2');
-});
+})->with([
+    'spatie/laravel-fast-paginate',
+    'aaronfrancis/fast-paginate',
+    'hammerstone/fast-paginate',
+]);
 
-it('uses the simpleFastPaginate macro when simple pagination is on', function () {
+it('simple fast paginates when a known package is installed', function () {
     config()->set('json-api-paginate.use_simple_pagination', true);
 
-    EloquentBuilder::macro('simpleFastPaginate', fn (...$arguments) => $this->simplePaginate(...$arguments));
+    pretendPackageIsInstalled('spatie/laravel-fast-paginate');
 
     expect(TestModel::jsonPaginate()->nextPageUrl())
         ->toEqual('http://localhost?page%5Bnumber%5D=2');
 });
 
-it('aborts when no package provides fast pagination', function () {
+it('aborts when no fast pagination package is installed', function () {
     TestModel::jsonPaginate();
-})->throws(HttpException::class, 'No installed package provides a `fastPaginate` method.');
+})->throws(HttpException::class, 'You need to install spatie/laravel-fast-paginate to use fast pagination.');
 
-it('aborts on a query builder, which fast pagination packages do not cover', function () {
-    EloquentBuilder::macro('fastPaginate', fn (...$arguments) => $this->paginate(...$arguments));
-
-    DB::table('test_models')->jsonPaginate();
-})->throws(HttpException::class, 'No installed package provides a `fastPaginate` method.');
-
-it('does not look for a macro when fast pagination is off', function () {
+it('does not look for a package when fast pagination is off', function () {
     config()->set('json-api-paginate.use_fast_pagination', false);
 
     expect(TestModel::jsonPaginate()->nextPageUrl())

--- a/tests/FastPaginationTest.php
+++ b/tests/FastPaginationTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
+use Illuminate\Support\Facades\DB;
+use Spatie\JsonApiPaginate\Test\TestModel;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+// Eloquent's builder keeps its global macros in a static, and has no way to unregister
+// one, so we put back whatever was registered before each test.
+beforeEach(function () {
+    config()->set('json-api-paginate.use_fast_pagination', true);
+
+    $this->registeredMacros = new ReflectionProperty(EloquentBuilder::class, 'macros');
+    $this->originalMacros = $this->registeredMacros->getValue();
+});
+
+afterEach(function () {
+    $this->registeredMacros->setValue(null, $this->originalMacros);
+});
+
+it('uses the fastPaginate macro when a package provides one', function () {
+    EloquentBuilder::macro('fastPaginate', fn (...$arguments) => $this->paginate(...$arguments));
+
+    expect(TestModel::jsonPaginate()->nextPageUrl())
+        ->toEqual('http://localhost?page%5Bnumber%5D=2');
+});
+
+it('uses the simpleFastPaginate macro when simple pagination is on', function () {
+    config()->set('json-api-paginate.use_simple_pagination', true);
+
+    EloquentBuilder::macro('simpleFastPaginate', fn (...$arguments) => $this->simplePaginate(...$arguments));
+
+    expect(TestModel::jsonPaginate()->nextPageUrl())
+        ->toEqual('http://localhost?page%5Bnumber%5D=2');
+});
+
+it('aborts when no package provides fast pagination', function () {
+    TestModel::jsonPaginate();
+})->throws(HttpException::class, 'No installed package provides a `fastPaginate` method.');
+
+it('aborts on a query builder, which fast pagination packages do not cover', function () {
+    EloquentBuilder::macro('fastPaginate', fn (...$arguments) => $this->paginate(...$arguments));
+
+    DB::table('test_models')->jsonPaginate();
+})->throws(HttpException::class, 'No installed package provides a `fastPaginate` method.');
+
+it('does not look for a macro when fast pagination is off', function () {
+    config()->set('json-api-paginate.use_fast_pagination', false);
+
+    expect(TestModel::jsonPaginate()->nextPageUrl())
+        ->toEqual('http://localhost?page%5Bnumber%5D=2');
+});


### PR DESCRIPTION
Seeing as the `hammerstone/fast-paginate` package is archived, and `aarondfrancis/fast-paginate` is not updated to Laravel 13, it would be nice to be able to write a custom macro to use the fast pagination, like the one written in https://github.com/aarondfrancis/fast-paginate/issues/81